### PR TITLE
double colorless changes

### DIFF
--- a/data/src/main/resources/cards/114-base_set_2.yaml
+++ b/data/src/main/resources/cards/114-base_set_2.yaml
@@ -2841,13 +2841,10 @@ cards:
   enumId: SUPER_POTION_117
   name: Super Potion
   number: '117'
-  superType: TRAINER
-  subTypes: []
   rarity: Uncommon
-  text:
-  - Discard 1 Energy card attached to 1 of your own Pokémon in order to remove up
-    to 4 damage counters from that Pokémon.
-  artist: Keiji Kinebuchi
+  variantOf: 111-90
+  variantType: REPRINT
+
 - id: 114-118
   pioId: base4-118
   enumId: BILL_118
@@ -2888,48 +2885,39 @@ cards:
   enumId: POKE_BALL_121
   name: Poké Ball
   number: '121'
-  superType: TRAINER
-  subTypes: []
   rarity: Common
-  text:
-  - Flip a coin. If heads, you may search your deck for any Basic Pokémon or Evolution
-    card. Show that card to your opponent, then put it into your hand. Shuffle your
-    deck afterward.
+  variantOf: 112-64
+  variantType: REPRINT
+  
   artist: Keiji Kinebuchi
 - id: 114-122
   pioId: base4-122
   enumId: POTION_122
   name: Potion
   number: '122'
-  superType: TRAINER
-  subTypes: []
   rarity: Common
-  text:
-  - Remove up to 2 damage counters from 1 of your Pokémon.
-  artist: Keiji Kinebuchi
+  variantOf: 111-94
+  variantType: REPRINT
+  
 - id: 114-123
   pioId: base4-123
   enumId: SWITCH_123
   name: Switch
   number: '123'
-  superType: TRAINER
-  subTypes: []
   rarity: Common
-  text:
-  - Switch 1 of your Benched Pokémon with your Active Pokémon.
-  artist: Keiji Kinebuchi
+  variantOf: 111-95
+  variantType: REPRINT
+  
+
 - id: 114-124
   pioId: base4-124
   enumId: DOUBLE_COLORLESS_ENERGY_124
   name: Double Colorless Energy
   number: '124'
-  superType: ENERGY
-  subTypes: [SPECIAL_ENERGY]
   rarity: Uncommon
-  text:
-  - Provides energy. Doesn't count as a basic energy card.
-  energy: [[C], [C]]
-  artist: Keiji Kinebuchi
+  variantOf: 111-96
+  variantType: REPRINT
+
 - id: 114-125
   pioId: base4-125
   enumId: FIGHTING_ENERGY_125

--- a/data/src/main/resources/cards/271-heartgold_soulsilver.yaml
+++ b/data/src/main/resources/cards/271-heartgold_soulsilver.yaml
@@ -2454,12 +2454,11 @@ cards:
   enumId: DOUBLE_COLORLESS_ENERGY_103
   name: Double Colorless Energy
   number: '103'
-  superType: ENERGY
-  subTypes: [SPECIAL_ENERGY]
   rarity: Uncommon
-  text:
-  - Double [C] Energy provides 2 [C] Energy.
-  artist: Kent Kanetsuna
+  variantOf: 111-96
+  variantType: REPRINT
+  variantIsDifferent: true
+  
 - id: 271-104
   pioId: hgss1-104
   enumId: RAINBOW_ENERGY_104
@@ -2668,6 +2667,7 @@ cards:
   subTypes: [LEGEND]
   hp: 140
   retreatCost: 0
+  
   rarity: Ultra Rare
   text:
   - Put this card from your hand onto your Bench only with the other half of Ho-Oh

--- a/data/src/main/resources/cards/314-next_destinies.yaml
+++ b/data/src/main/resources/cards/314-next_destinies.yaml
@@ -2286,13 +2286,10 @@ cards:
   enumId: DOUBLE_COLORLESS_ENERGY_92
   name: Double Colorless Energy
   number: '92'
-  superType: ENERGY
-  subTypes: [SPECIAL_ENERGY]
   rarity: Uncommon
-  text:
-  - Double Colorless Energy provides [C][C] Energy.
-  energy: [[C], [C]]
-  artist: 5ban Graphics
+  variantOf: 271-103
+  variantType: REPRINT
+
 - id: 314-93
   pioId: bw4-93
   enumId: PRISM_ENERGY_93

--- a/data/src/main/resources/cards/322-legendary_treasures.yaml
+++ b/data/src/main/resources/cards/322-legendary_treasures.yaml
@@ -2818,13 +2818,9 @@ cards:
   enumId: DOUBLE_COLORLESS_ENERGY_113
   name: Double Colorless Energy
   number: '113'
-  superType: ENERGY
-  subTypes: [SPECIAL_ENERGY]
   rarity: Uncommon
-  text:
-  - Double Colorless Energy provides [C][C] Energy.
-  energy: [[C], [C]]
-  artist: 5ban Graphics
+  variantOf: 271-103
+  variantType: REPRINT
 - id: 322-114
   pioId: bw11-114
   enumId: RESHIRAM_114

--- a/data/src/main/resources/cards/361-xy.yaml
+++ b/data/src/main/resources/cards/361-xy.yaml
@@ -3192,13 +3192,9 @@ cards:
   enumId: DOUBLE_COLORLESS_ENERGY_130
   name: Double Colorless Energy
   number: '130'
-  superType: ENERGY
-  subTypes: [SPECIAL_ENERGY]
   rarity: Uncommon
-  text:
-  - Double Colorless Energy provides [C][C] Energy.
-  energy: [[C], [C]]
-  artist: 5ban Graphics
+  variantOf: 271-103
+  variantType: REPRINT
 - id: 361-131
   pioId: xy1-131
   enumId: RAINBOW_ENERGY_131

--- a/data/src/main/resources/cards/364-phantom_forces.yaml
+++ b/data/src/main/resources/cards/364-phantom_forces.yaml
@@ -1,4 +1,4 @@
-schema: E2
+blschema: E2
 id: '364'
 name: Phantom Forces
 enumId: PHANTOM_FORCES
@@ -2698,12 +2698,9 @@ cards:
   name: Double Colorless Energy
   number: '111'
   superType: ENERGY
-  subTypes: [SPECIAL_ENERGY]
   rarity: Uncommon
-  text:
-  - Double Colorless Energy provides [C][C] Energy.
-  energy: [[C], [C]]
-  artist: 5ban Graphics
+  variantOf: 271-103
+  variantType: REPRINT
 - id: 364-112
   pioId: xy4-112
   enumId: MYSTERY_ENERGY_112

--- a/data/src/main/resources/cards/371-generations.yaml
+++ b/data/src/main/resources/cards/371-generations.yaml
@@ -1764,13 +1764,9 @@ cards:
   enumId: DOUBLE_COLORLESS_ENERGY_74
   name: Double Colorless Energy
   number: '74'
-  superType: ENERGY
-  subTypes: [SPECIAL_ENERGY]
   rarity: Uncommon
-  text:
-  - Double Colorless Energy provides [C][C] Energy.
-  energy: [[C], [C]]
-  artist: 5ban Graphics
+  variantOf: 271-103
+  variantType: REPRINT
 - id: 371-75
   pioId: g1-75
   enumId: GRASS_ENERGY_75

--- a/data/src/main/resources/cards/372-fates_collide.yaml
+++ b/data/src/main/resources/cards/372-fates_collide.yaml
@@ -2686,13 +2686,9 @@ cards:
   enumId: DOUBLE_COLORLESS_ENERGY_114
   name: Double Colorless Energy
   number: '114'
-  superType: ENERGY
-  subTypes: [SPECIAL_ENERGY]
   rarity: Uncommon
-  text:
-  - Double Colorless Energy provides [C][C] Energy.
-  energy: [[C], [C]]
-  artist: 5ban Graphics
+  variantOf: 271-103
+  variantType: REPRINT
 - id: 372-115
   pioId: xy10-115
   enumId: STRONG_ENERGY_115

--- a/data/src/main/resources/cards/374-evolutions.yaml
+++ b/data/src/main/resources/cards/374-evolutions.yaml
@@ -2081,13 +2081,9 @@ cards:
   enumId: DOUBLE_COLORLESS_ENERGY_90
   name: Double Colorless Energy
   number: '90'
-  superType: ENERGY
-  subTypes: [SPECIAL_ENERGY]
   rarity: Uncommon
-  text:
-  - Double Colorless Energy provides [C][C] Energy.
-  energy: [[C], [C]]
-  artist: Keiji Kinebuchi
+  variantOf: 271-103
+  variantType: REPRINT
 - id: 374-91
   pioId: xy12-91
   enumId: GRASS_ENERGY_91

--- a/data/src/main/resources/cards/411-sun_moon.yaml
+++ b/data/src/main/resources/cards/411-sun_moon.yaml
@@ -3319,13 +3319,9 @@ cards:
   enumId: DOUBLE_COLORLESS_ENERGY_136
   name: Double Colorless Energy
   number: '136'
-  superType: ENERGY
-  subTypes: [SPECIAL_ENERGY]
   rarity: Uncommon
-  text:
-  - Double Colorless Energy provides [C][C] Energy.
-  energy: [[C], [C]]
-  artist: 5ban Graphics
+  variantOf: 271-103
+  variantType: REPRINT
 - id: 411-137
   pioId: sm1-137
   enumId: RAINBOW_ENERGY_137

--- a/data/src/main/resources/cards/412-guardians_rising.yaml
+++ b/data/src/main/resources/cards/412-guardians_rising.yaml
@@ -4481,13 +4481,9 @@ cards:
   enumId: DOUBLE_COLORLESS_ENERGY_166
   name: Double Colorless Energy
   number: '166'
-  superType: ENERGY
-  subTypes: [SPECIAL_ENERGY]
   rarity: Secret
-  text:
-  - Double Colorless Energy provides [C][C] Energy.
-  energy: [[C], [C]]
-  artist: 5ban Graphics
+  variantOf: 271-103
+  variantType: REPRINT
 - id: 412-167
   pioId: sm2-167
   enumId: GRASS_ENERGY_167

--- a/data/src/main/resources/cards/414-shining_legends.yaml
+++ b/data/src/main/resources/cards/414-shining_legends.yaml
@@ -1668,13 +1668,9 @@ cards:
   enumId: DOUBLE_COLORLESS_ENERGY_69
   name: Double Colorless Energy
   number: '69'
-  superType: ENERGY
-  subTypes: [SPECIAL_ENERGY]
   rarity: Uncommon
-  text:
-  - Double Colorless Energy provides [C][C] Energy.
-  energy: [[C], [C]]
-  artist: ''
+  variantOf: 271-103
+  variantType: REPRINT
 - id: 414-70
   pioId: sm35-70
   enumId: WARP_ENERGY_70


### PR DESCRIPTION
dce from heart gold soul silver to shining legends changed to fit the reprint system